### PR TITLE
✨ FEATURE: 흘러간 시간 계산, 날짜 정렬하는 유틸 함수 추가

### DIFF
--- a/@types/auth.ts
+++ b/@types/auth.ts
@@ -1,7 +1,7 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   type BaseAuthEntity = {
-    createdAt: string;
-    updatedAt: string;
+    createdAt: ISODateString;
+    updatedAt: ISODateString;
     id: number;
   };
 

--- a/@types/comment.ts
+++ b/@types/comment.ts
@@ -1,7 +1,7 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   type BaseCommentEntity = {
-    updatedAt: string;
-    createdAt: string;
+    updatedAt: ISODateString;
+    createdAt: ISODateString;
     id: number;
   };
 

--- a/@types/date.ts
+++ b/@types/date.ts
@@ -1,0 +1,3 @@
+declare module "@coworkers-types" {
+  export type ISODateString = string;
+}

--- a/@types/group.ts
+++ b/@types/group.ts
@@ -1,7 +1,7 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   type BaseGroupEntity = {
-    updatedAt: string;
-    createdAt: string;
+    updatedAt: ISODateString;
+    createdAt: ISODateString;
     name: string;
     id: number;
   };
@@ -13,7 +13,7 @@ declare module '@coworkers-types' {
     taskLists: GroupTaskLists[];
   };
 
-  export type GroupInfo = Omit<Group, 'members' | 'taskLists'>;
+  export type GroupInfo = Omit<Group, "members" | "taskLists">;
 
   export type GroupTaskLists = BaseGroupEntity & {
     groupId: number;

--- a/@types/task.ts
+++ b/@types/task.ts
@@ -1,36 +1,30 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   export type BaseTaskEntity = {
     name: string;
     description: string;
     displayIndex: number;
     frequencyType: string;
     monthDay: number;
-    updatedAt: string;
-    createdAt: string;
+    updatedAt: ISODateString;
+    createdAt: ISODateString;
     id: number;
   };
 
   export type BaseTaskDetails = {
-    deletedAt: string;
+    deletedAt: ISODateString;
     userId: number;
     recurringId: number;
     frequency: string;
-    date: string;
-    doneAt: string;
+    date: ISODateString;
+    doneAt: ISODateString;
     name: string;
-    updatedAt: string;
+    updatedAt: ISODateString;
     id: number;
   };
 
-  export type PostTaskRequest = Omit<
-    BaseTaskEntity,
-    'updatedAt' | 'createdAt' | 'id'
-  >;
+  export type PostTaskRequest = Omit<BaseTaskEntity, "updatedAt" | "createdAt" | "id">;
 
-  export type PatchTaskRequest = Omit<
-    PostTaskRequest,
-    'frequencyType' | 'monthDay'
-  > & {
+  export type PatchTaskRequest = Omit<PostTaskRequest, "frequencyType" | "monthDay"> & {
     done: boolean;
   };
 

--- a/@types/taskList.ts
+++ b/@types/taskList.ts
@@ -1,15 +1,15 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   export type TaskList = {
     groupId: number;
     displayIndex: number;
-    updatedAt: string;
-    createdAt: string;
+    updatedAt: ISODateString;
+    createdAt: ISODateString;
     name: string;
     id: number;
     tasks: DateTask[];
   };
 
-  export type TaskListInfo = Omit<TaskList, 'tasks'>;
+  export type TaskListInfo = Omit<TaskList, "tasks">;
 
   export type PatchTaskListOrder = {
     displayIndex: number;

--- a/@types/user.ts
+++ b/@types/user.ts
@@ -1,7 +1,7 @@
-declare module '@coworkers-types' {
+declare module "@coworkers-types" {
   type BaseUserEntity = {
-    updatedAt: string;
-    createdAt: string;
+    updatedAt: ISODateString;
+    createdAt: ISODateString;
     id: number;
   };
 
@@ -35,12 +35,12 @@ declare module '@coworkers-types' {
   };
 
   export type TasksDone = BaseUserEntity & {
-    deletedAt: string;
+    deletedAt: ISODateString;
     userId: number;
     recurringId: number;
     frequency: string;
-    date: string;
-    doneAt: string;
+    date: ISODateString;
+    doneAt: ISODateString;
     description: string;
     name: string;
   };

--- a/src/utils/calculateElapsedTime.ts
+++ b/src/utils/calculateElapsedTime.ts
@@ -1,0 +1,34 @@
+import { formatDate } from "./formatDate";
+
+/**
+ * 전달받은 시간이 현 시점으로부터 얼마나 지났는지 계산하는 함수입니다.
+ * @param dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
+ * @returns "방금전", "1분전" ~ "2년전" 까지의 문자열을 리턴하고 3년 이상의 시간이 지났으면 "2024.07.25"와 같은 형식의 문자열을 반환합니다.
+ */
+
+export const calculateElapsedTime = (dateString: string) => {
+  const timeObject = new Date(dateString);
+  const timeInMilliseconds = timeObject.getTime();
+
+  const timeDifference = Date.now() - timeInMilliseconds;
+
+  const seconds = Math.floor(timeDifference / 1000);
+  if (seconds < 60) return "방금전";
+
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${Math.floor(minutes)}분전`;
+
+  const hours = minutes / 60;
+  if (hours < 24) return `${Math.floor(hours)}시간전`;
+
+  const days = hours / 24;
+  if (days < 7) return `${Math.floor(days)}일전`;
+
+  const weeks = days / 7;
+  if (weeks < 52) return `${Math.floor(weeks)}주전`;
+
+  const years = weeks / 52;
+  if (years < 3) return `${Math.floor(years)}년전`;
+
+  return formatDate(dateString);
+};

--- a/src/utils/calculateElapsedTime.ts
+++ b/src/utils/calculateElapsedTime.ts
@@ -1,14 +1,17 @@
+import { ISODateString } from "@coworkers-types";
 import { formatDate } from "./formatDate";
 
 /**
  * 전달받은 시간이 현 시점으로부터 얼마나 지났는지 계산하는 함수입니다.
- * @param dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
+ * @param dateString - ISODateString 타입의 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
  * @returns "방금전", "1분전" ~ "2년전" 까지의 문자열을 리턴하고 3년 이상의 시간이 지났으면 "2024.07.25"와 같은 형식의 문자열을 반환합니다.
  */
 
-export const calculateElapsedTime = (dateString: string) => {
+export const calculateElapsedTime = (dateString: ISODateString) => {
   const timeObject = new Date(dateString);
   const timeInMilliseconds = timeObject.getTime();
+
+  if (Number.isNaN(timeInMilliseconds)) return "Invalid date string format";
 
   const timeDifference = Date.now() - timeInMilliseconds;
 
@@ -27,7 +30,7 @@ export const calculateElapsedTime = (dateString: string) => {
   const weeks = days / 7;
   if (weeks < 52) return `${Math.floor(weeks)}주전`;
 
-  const years = weeks / 52;
+  const years = days / 365.25; // 윤년을 고려하여 365.25로 계산
   if (years < 3) return `${Math.floor(years)}년전`;
 
   return formatDate(dateString);

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,12 +1,17 @@
+import { ISODateString } from "@coworkers-types";
+
 /**
  * 날짜 문자열을 받아 일정 형식으로 정렬합니다.
- * @param dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
+ * @param dateString - ISODateString 타입의 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
  * @param type - 리턴받을 문자열의 종류를 정합니다. default의 경우 "2024.07.01" 형식, kor의 경우 "2024년 7월 1일" 형식의 문자열을 리턴합니다. 기본값은 "default"입니다.
  * @returns type에 따라 "2024.07.01" 형식 또는 "2024년 7월 1일" 형식의 문자열을 반환합니다.
  */
 
-export const formatDate = (dateString: string, type: "default" | "kor" = "default") => {
+export const formatDate = (dateString: ISODateString, type: "default" | "kor" = "default") => {
   const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) return "Invalid date string format";
+
   const year = date.getFullYear();
   const month =
     type === "default" ? String(date.getMonth() + 1).padStart(2, "0") : String(date.getMonth() + 1);

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,15 @@
+/**
+ * 날짜 문자열을 받아 일정 형식으로 정렬합니다.
+ * @param dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.
+ * @param type - 리턴받을 문자열의 종류를 정합니다. default의 경우 "2024.07.01" 형식, kor의 경우 "2024년 7월 1일" 형식의 문자열을 리턴합니다. 기본값은 "default"입니다.
+ * @returns type에 따라 "2024.07.01" 형식 또는 "2024년 7월 1일" 형식의 문자열을 반환합니다.
+ */
+
+export const formatDate = (dateString: string, type: "default" | "kor" = "default"): string => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month =
+    type === "default" ? String(date.getMonth() + 1).padStart(2, "0") : String(date.getMonth() + 1);
+  const day = type === "default" ? String(date.getDate()).padStart(2, "0") : String(date.getDate());
+  return type === "default" ? `${year}.${month}.${day}` : `${year}년 ${month}월 ${day}일`;
+};

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -5,7 +5,7 @@
  * @returns type에 따라 "2024.07.01" 형식 또는 "2024년 7월 1일" 형식의 문자열을 반환합니다.
  */
 
-export const formatDate = (dateString: string, type: "default" | "kor" = "default"): string => {
+export const formatDate = (dateString: string, type: "default" | "kor" = "default") => {
   const date = new Date(dateString);
   const year = date.getFullYear();
   const month =


### PR DESCRIPTION
## 연관된 지라 이슈

FE-75

## 작업 내용
### formatDate 함수 - 날짜 문자열을 받아 일정 형식으로 정렬합니다.

- dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.

- type - 리턴받을 문자열의 종류를 정합니다. default의 경우 "2024.07.01" 형식, kor의 경우 "2024년 7월 1일" 형식의 문자열을 리턴합니다. 기본값은 "default"입니다.

- type에 따라 "2024.07.01" 형식 또는 "2024년 7월 1일" 형식의 문자열을 반환합니다.

### calculateElapsedTime 함수 - 전달받은 시간이 현 시점으로부터 얼마나 지났는지 계산하는 함수입니다.

- dateString - 날짜 문자열(ex "2024-07-01T07:20:51.162Z")입니다.

- "방금전", "1분전" ~ "2년전" 까지의 문자열을 리턴하고 3년 이상의 시간이 지났으면 "2024.07.25"와 같은 형식의 문자열을 반환합니다.

## 스크린샷
X

## 코멘트 및 논의 사항
X
