### PR TITLE
♻️ REFACTOR: 모달 훅 props 수정

### DIFF
--- a/src/components/commons/Button/index.tsx
+++ b/src/components/commons/Button/index.tsx
@@ -5,7 +5,6 @@ import Spinner from "../Spinner";
 
 export type ButtonProps = {
   buttonType?: "button" | "floating";
-  type?: "button" | "submit";
   size?: "large" | "medium" | "small";
   icon?: "none" | "check" | "plus";
   buttonStyle?:
@@ -38,7 +37,6 @@ export type ButtonProps = {
  */
 export default function Button({
   buttonType = "button",
-  type = "button",
   size = "large",
   icon = "none",
   buttonStyle = "default",

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -3,6 +3,15 @@ import { useModalStore } from "../store/useModalStore";
 
 interface ModalProps {
   onClose?: () => void;
+  onChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
+  firstOnChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
+  secondOnChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
 }
 
 interface UseModal {

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -3,6 +3,15 @@ import create from "zustand";
 
 interface ModalProps {
   onClose?: () => void;
+  onChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
+  firstOnChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
+  secondOnChange?:
+    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
+    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
 }
 
 interface ModalState {


### PR DESCRIPTION
## 연관된 지라 이슈

FE-103

## 작업 내용

```js
interface ModalProps {
  onClose?: () => void;
  onConfirm?: () => void;
  onChange?:
    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
  firstOnChange?:
    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
  secondOnChange?:
    | ((event: React.ChangeEvent<HTMLInputElement>) => void)
    | ((event: React.ChangeEvent<HTMLTextAreaElement>) => void);
}
```
혹시 몰라서 onConfirm이랑 onChange 부분도 추가해뒀습니다
현정님이 구현했던 SendMailModal.tsx는 컴포넌트에서 자체적으로 onChange 함수를 만들어서 넘겨주었지만
부모컴포넌트에서 넘겨줘야될 상황이 있을것같아서 추가했습니다 !

## 스크린샷

## 코멘트 및 논의 사항

바로 머지하겠습니다 ~
