### PR TITLE
✨ FEATURE: 할일 상세보기 사이드바

### DIFF
--- a/@types/task.ts
+++ b/@types/task.ts
@@ -111,7 +111,7 @@ declare module "@coworkers-types" {
     id: number;
   };
 
-  export type Recurring =  {
+  export type Recurring = {
     id: number;
     name: string;
     description: string;

--- a/@types/task.ts
+++ b/@types/task.ts
@@ -11,7 +11,7 @@ declare module "@coworkers-types" {
   };
 
   export type BaseTaskDetails = {
-    deletedAt: ISODateString;
+    deletedAt: ISODateString | null;
     userId: number;
     recurringId: number;
     frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
@@ -71,11 +71,23 @@ declare module "@coworkers-types" {
     frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
   };
 
-  export type TaskDetails = BaseTaskDetails & {
-    comments: TaskCommentInfo[];
+  export type TaskDetails = {
+    id: number;
+    name: string;
+    description: string | null;
+    date: ISODateString;
+    doneAt: ISODateString | null;
+    updatedAt: ISODateString;
+    recurringId: number;
+    deletedAt: ISODateString | null;
+    displayIndex: number;
+    writer: TaskUserInfo | null;
+    doneBy: {
+      user: TaskUserInfo | null;
+    };
+    commentCount: number;
+    frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
     recurring: Recurring;
-    user: TaskUserInfo;
-    description: string;
   };
 
   export type PatchTaskResponse = {
@@ -94,14 +106,23 @@ declare module "@coworkers-types" {
   };
 
   export type TaskUserInfo = {
-    image: string;
+    image: string | null;
     nickname: string;
     id: number;
   };
 
-  export type Recurring = BaseTaskEntity & {
+  export type Recurring =  {
     groupId: number;
     taskListId: number;
-    weekDays: number[];
+    id: number;
+    name: string;
+    description: string;
+    createdAt: ISODateString;
+    updatedAt: ISODateString;
+    startDate: ISODateString;
+    frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
+    weekDays: number[] | null;
+    monthDay: number | null;
+    writerId: number | null;
   };
 }

--- a/@types/task.ts
+++ b/@types/task.ts
@@ -73,21 +73,21 @@ declare module "@coworkers-types" {
 
   export type TaskDetails = {
     id: number;
-    name: string;
-    description: string | null;
+    updatedAt: ISODateString;
     date: ISODateString;
     doneAt: ISODateString | null;
-    updatedAt: ISODateString;
     recurringId: number;
+    name: string;
+    description: string;
+    frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
     deletedAt: ISODateString | null;
     displayIndex: number;
-    writer: TaskUserInfo | null;
+    recurring: Recurring;
+    writer: TaskUserInfo;
     doneBy: {
       user: TaskUserInfo | null;
     };
     commentCount: number;
-    frequency: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
-    recurring: Recurring;
   };
 
   export type PatchTaskResponse = {
@@ -112,8 +112,6 @@ declare module "@coworkers-types" {
   };
 
   export type Recurring =  {
-    groupId: number;
-    taskListId: number;
     id: number;
     name: string;
     description: string;
@@ -123,6 +121,8 @@ declare module "@coworkers-types" {
     frequencyType: "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
     weekDays: number[] | null;
     monthDay: number | null;
-    writerId: number | null;
+    taskListId: number;
+    groupId: number;
+    writerId: number;
   };
 }

--- a/@types/taskComment.ts
+++ b/@types/taskComment.ts
@@ -5,15 +5,10 @@ declare module "@coworkers-types" {
     id: number;
   };
 
-  type TaskCommentUserInfo = BaseCommentEntity & {
-    teamId: string;
+  type TaskCommentUserInfo = {
     image: string | null;
     nickname: string;
-    email: string;
-  };
-
-  export type TaskCommentWriterInfo = TaskCommentUserInfo & {
-    encryptedPassword: string;
+    id: number;
   };
 
   export type TaskCommentInfo = BaseCommentEntity & {
@@ -22,7 +17,13 @@ declare module "@coworkers-types" {
     content: string;
   };
 
-  export type TaskComment = { user: TaskCommentWriterInfo } & TaskCommentInfo;
+  export type TaskComment = { user: TaskCommentUserInfo } & TaskCommentInfo;
 
   export type TaskCommentList = TaskComment[];
 }
+
+// user: {
+//   image: string | null;
+//   nickname: string;
+//   id: number;
+// }

--- a/src/components/task-list-page/CreateTaskModal.tsx
+++ b/src/components/task-list-page/CreateTaskModal.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useState } from "react";
 import { PostTaskRequest } from "@coworkers-types";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format, setHours, setMinutes } from "date-fns";
 import { useRouter } from "next/router";
 import Button from "@components/commons/Button";
@@ -25,6 +25,8 @@ export default function CreateTaskModal({ onClose }: { onClose?: () => void }) {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedTime, setSelectedTime] = useState("AM 9:00");
   const initialDate = setHours(setMinutes(new Date(), 0), 9);
+
+  const queryClient = useQueryClient();
 
   const [task, setTask] = useState<PostTaskRequest>({
     name: "",
@@ -93,6 +95,7 @@ export default function CreateTaskModal({ onClose }: { onClose?: () => void }) {
     onSuccess: () => {
       closeModal();
       updateURL(selectedDate, taskListsId);
+      queryClient.invalidateQueries({ queryKey: ["taskLists"] });
     },
     onError: (error: any) => {
       toast("danger", `${error.response.data.message}`);

--- a/src/components/task-list-page/Sidebar.tsx
+++ b/src/components/task-list-page/Sidebar.tsx
@@ -1,13 +1,22 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { TaskCommentList, TaskDetails } from "@coworkers-types";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import classNames from "classnames";
 import { format } from "date-fns";
 import Button from "@components/commons/Button";
 import Comment from "@components/commons/Comment";
+import Input from "@components/commons/Input";
 import NameTag from "@components/commons/NameTag";
 import EditDeletePopover from "@components/commons/Popover/EditDeletePopover";
-import { IconCalender, IconClose, IconRepeat, IconTime } from "@utils/icon";
+import Textarea from "@components/commons/TextArea";
+import {
+  IconCalender,
+  IconClose,
+  IconEnterActive,
+  IconEnterDefault,
+  IconRepeat,
+  IconTime,
+} from "@utils/icon";
 import { getTaskDetails } from "@api/taskApi";
 import { getTaskComments } from "@api/taskCommentApi";
 
@@ -23,6 +32,7 @@ export default function Sidebar({
   onClose: Dispatch<SetStateAction<boolean>>;
 }) {
   // const side = useRef();
+  const [textareaComment, setTextareaComment] = useState<string>("");
 
   const { data: TaskDetailData } = useQuery<TaskDetails>({
     queryKey: ["taskListDetail", taskId],
@@ -73,12 +83,18 @@ export default function Sidebar({
     }
   }
 
+  const handleChangeTextarea = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextareaComment(event.target.value);
+  };
+
   const formatClass = classNames("text-text-default text-12");
 
   const lineClass = classNames("h-10 border border-l border-solid border-background-tertiary");
 
+  const postIconClass = classNames("absolute right-0 top-13 cursor-pointer");
+
   return (
-    <div className="h-full w-full bg-background-secondary md:fixed md:right-0 md:top-61 md:w-435 lg:w-779">
+    <div className="z-[999] h-full w-full bg-background-secondary md:fixed md:right-0 md:top-61 md:w-435 lg:w-779">
       <div className="flex h-full flex-col gap-16 p-24">
         <IconClose className="cursor-pointer" onClick={onClose} />
         <div className="flex justify-between">
@@ -104,6 +120,20 @@ export default function Sidebar({
           <p className={formatClass}>{frequency}</p>
         </div>
         <div className="h-200 overflow-y-scroll">{TaskDetailData?.description}</div>
+        <div className="relative">
+          <Textarea
+            type="innerButton"
+            placeholder="댓글을 달아주세요."
+            height={50}
+            value={textareaComment}
+            onChange={handleChangeTextarea}
+          />
+          {textareaComment.length > 0 ? (
+            <IconEnterActive className={postIconClass} />
+          ) : (
+            <IconEnterDefault className={postIconClass} />
+          )}
+        </div>
         {TaskCommentData?.map((comment) => <Comment type="task" comment={comment} />)}
         <Button
           buttonType="floating"

--- a/src/components/task-list-page/Sidebar.tsx
+++ b/src/components/task-list-page/Sidebar.tsx
@@ -94,7 +94,7 @@ export default function Sidebar({
   const postIconClass = classNames("absolute right-0 top-13 cursor-pointer");
 
   return (
-    <div className="z-[999] h-full w-full bg-background-secondary md:fixed md:right-0 md:top-61 md:w-435 lg:w-779">
+    <div className="fixed right-0 top-61 z-[999] h-full w-full bg-background-secondary md:left-auto md:top-61 md:w-435 lg:w-779">
       <div className="flex h-full flex-col gap-16 p-24">
         <IconClose className="cursor-pointer" onClick={onClose} />
         <div className="flex justify-between">

--- a/src/components/task-list-page/Sidebar.tsx
+++ b/src/components/task-list-page/Sidebar.tsx
@@ -157,7 +157,7 @@ export default function Sidebar({
       <div className="flex h-full flex-col gap-16 p-24">
         <IconClose className="cursor-pointer" onClick={onClose} />
         <div className="flex justify-between">
-          {TaskDetailData?.name}
+          <p className="text-20 font-bold text-text-primary">{TaskDetailData?.name}</p>
           <EditDeletePopover icon="kebabLarge" handleModify={() => {}} handleDelete={() => {}} />
         </div>
         <div className="flex justify-between">
@@ -166,7 +166,7 @@ export default function Sidebar({
             image={TaskDetailData?.writer.image ?? null}
             name={TaskDetailData?.writer.nickname as string}
           />
-          {formattedCreatedDate}
+          <p className="text-14 text-text-secondary">{formattedCreatedDate}</p>
         </div>
         <div className="flex items-center gap-10">
           <IconCalender />
@@ -178,7 +178,9 @@ export default function Sidebar({
           <IconRepeat />
           <p className={formatClass}>{frequency}</p>
         </div>
-        <div className="h-200 overflow-y-scroll">{TaskDetailData?.description}</div>
+        <div className="h-200">
+          <p className="text-14 text-text-primary">{TaskDetailData?.description}</p>
+        </div>
         <div className="relative">
           <Textarea
             type="innerButton"

--- a/src/components/task-list-page/Sidebar.tsx
+++ b/src/components/task-list-page/Sidebar.tsx
@@ -1,0 +1,119 @@
+import { Dispatch, SetStateAction } from "react";
+import { TaskCommentList, TaskDetails } from "@coworkers-types";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import classNames from "classnames";
+import { format } from "date-fns";
+import Button from "@components/commons/Button";
+import Comment from "@components/commons/Comment";
+import NameTag from "@components/commons/NameTag";
+import EditDeletePopover from "@components/commons/Popover/EditDeletePopover";
+import { IconCalender, IconClose, IconRepeat, IconTime } from "@utils/icon";
+import { getTaskDetails } from "@api/taskApi";
+import { getTaskComments } from "@api/taskCommentApi";
+
+export default function Sidebar({
+  groupId,
+  taskId,
+  taskListId,
+  onClose,
+}: {
+  groupId: string;
+  taskId: number;
+  taskListId: string;
+  onClose: Dispatch<SetStateAction<boolean>>;
+}) {
+  // const side = useRef();
+
+  const { data: TaskDetailData } = useQuery<TaskDetails>({
+    queryKey: ["taskListDetail", taskId],
+    queryFn: () => getTaskDetails(Number(groupId), Number(taskListId), taskId),
+    placeholderData: keepPreviousData,
+  });
+
+  const { data: TaskCommentData } = useQuery<TaskCommentList>({
+    queryKey: ["taskComments", taskId],
+    queryFn: () => getTaskComments(taskId),
+    placeholderData: keepPreviousData,
+  });
+
+  const formattedCreatedDate = TaskDetailData?.recurring.createdAt
+    ? format(new Date(TaskDetailData.recurring.createdAt), "yyyy.MM.dd")
+    : "";
+
+  const formattedStartedDate = TaskDetailData?.recurring.startDate
+    ? format(new Date(TaskDetailData.recurring.startDate), "yyyy년 M월 dd일")
+    : "";
+
+  const formattedStatedTime = TaskDetailData?.recurring.startDate
+    ? format(new Date(TaskDetailData.recurring.startDate), "a h:mm")
+    : "";
+
+  let frequency = "";
+
+  if (TaskDetailData?.recurring.frequencyType) {
+    if (TaskDetailData.recurring.frequencyType === "DAILY") {
+      frequency = "매일 반복";
+    } else if (TaskDetailData.recurring.frequencyType === "MONTHLY") {
+      frequency = `매월 ${TaskDetailData.recurring.monthDay}일`;
+    } else if (
+      TaskDetailData.recurring.frequencyType === "WEEKLY" &&
+      Array.isArray(TaskDetailData.recurring.weekDays)
+    ) {
+      const dayMap: { [key: number]: string } = {
+        1: "월요일",
+        2: "화요일",
+        3: "수요일",
+        4: "목요일",
+        5: "금요일",
+        6: "토요일",
+        7: "일요일",
+      };
+      const days = TaskDetailData.recurring.weekDays.map((day) => dayMap[day]);
+      frequency = `매주 ${days.join(", ")}`;
+    }
+  }
+
+  const formatClass = classNames("text-text-default text-12");
+
+  const lineClass = classNames("h-10 border border-l border-solid border-background-tertiary");
+
+  return (
+    <div className="h-full w-full bg-background-secondary md:fixed md:right-0 md:top-61 md:w-435 lg:w-779">
+      <div className="flex h-full flex-col gap-16 p-24">
+        <IconClose className="cursor-pointer" onClick={onClose} />
+        <div className="flex justify-between">
+          {TaskDetailData?.name}
+          <EditDeletePopover icon="kebabLarge" handleModify={() => {}} handleDelete={() => {}} />
+        </div>
+        <div className="flex justify-between">
+          <NameTag
+            type="default-6"
+            image={TaskDetailData?.writer.image ?? null}
+            name={TaskDetailData?.writer.nickname as string}
+          />
+          {formattedCreatedDate}
+        </div>
+        <div className="flex items-center gap-10">
+          <IconCalender />
+          <p className={formatClass}>{formattedStartedDate}</p>
+          <span className={lineClass} />
+          <IconTime />
+          <p className={formatClass}>{formattedStatedTime}</p>
+          <span className={lineClass} />
+          <IconRepeat />
+          <p className={formatClass}>{frequency}</p>
+        </div>
+        <div className="h-200 overflow-y-scroll">{TaskDetailData?.description}</div>
+        {TaskCommentData?.map((comment) => <Comment type="task" comment={comment} />)}
+        <Button
+          buttonType="floating"
+          icon="check"
+          className="bottom-24 right-24 lg:bottom-48 lg:right-100"
+          onClick={() => console.log("asd")}
+        >
+          완료하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/task-list-page/Task.tsx
+++ b/src/components/task-list-page/Task.tsx
@@ -18,6 +18,7 @@ import { patchTaskCompletionStatus } from "@api/taskApi";
 
 type Props = {
   task: DateTask;
+  onClick: () => void;
 };
 
 const frequencyMap = {
@@ -27,7 +28,7 @@ const frequencyMap = {
   MONTHLY: "매월 반복",
 };
 
-export default function Task({ task }: Props) {
+export default function Task({ task, onClick }: Props) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { teamId, taskListsId } = router.query;
@@ -52,7 +53,10 @@ export default function Task({ task }: Props) {
   const handleDelete = () => {};
 
   return (
-    <div className="mb-16 flex w-full cursor-pointer flex-col gap-10 rounded-8 bg-background-secondary px-14 py-12">
+    <div
+      className="mb-16 flex w-full cursor-pointer flex-col gap-10 rounded-8 bg-background-secondary px-14 py-12"
+      onClick={onClick}
+    >
       <div className="flex items-center justify-between gap-8">
         <div className="flex grow justify-between md:justify-start md:gap-12">
           <div className="flex items-center gap-8">

--- a/src/components/task-list-page/Task.tsx
+++ b/src/components/task-list-page/Task.tsx
@@ -32,10 +32,9 @@ export default function Task({ task, onClick }: Props) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { teamId, taskListsId } = router.query;
-  const [isChecked, setIsChecked] = useState(task.doneAt !== null);
+  const isChecked = task.doneAt !== null;
   const [isEditMode, setIsEditMode] = useState(false);
   const handleCheckButton = () => {
-    setIsChecked((prev) => !prev);
     taskPatchMutation.mutate({ done: !isChecked });
   };
 

--- a/src/components/task-list-page/TaskList.tsx
+++ b/src/components/task-list-page/TaskList.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
-import { GroupTaskLists, TaskList } from "@coworkers-types";
-import { useQuery } from "@tanstack/react-query";
+import { Group, GroupTaskLists, TaskList } from "@coworkers-types";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import classNames from "classnames";
 import { useRouter } from "next/router";
 import Spinner from "@components/commons/Spinner";
 import { getGroup } from "@api/groupApi";
+import { getTaskDetails } from "@api/taskApi";
+import { getTaskComments } from "@api/taskCommentApi";
+import Sidebar from "./Sidebar";
 import Task from "./Task";
 
 type Props = {
@@ -12,15 +15,28 @@ type Props = {
   handleTaskListId: (id: string | string[] | undefined) => void;
   isLoading: boolean;
   isError: Error | null;
+  groupId: string;
+  taskListId: string;
 };
 
-export default function TaskLists({ taskLists, handleTaskListId, isLoading, isError }: Props) {
+export default function TaskLists({
+  taskLists,
+  handleTaskListId,
+  isLoading,
+  isError,
+  groupId,
+  taskListId,
+}: Props) {
   const router = useRouter();
   const { teamId, taskListsId } = router.query;
   const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+  const [isSidebarVisible, setIsSidebarVisible] = useState(false);
+
+  const queryClient = useQueryClient();
 
   // 탭의 정보를 받아오기 위해서 사용했는데, 추후에는 팀페이지에서 받은 그룹데이터를 getQueryClient 사용 예정
-  const { data: groupData } = useQuery({
+  const { data: groupData } = useQuery<Group>({
     queryKey: ["group", teamId],
     queryFn: () => getGroup(Number(teamId)),
     enabled: !!teamId,
@@ -39,6 +55,21 @@ export default function TaskLists({ taskLists, handleTaskListId, isLoading, isEr
     }
   }, [groupData, taskListsId]);
 
+  useEffect(() => {
+    groupData?.taskLists.forEach((tasks) => {
+      tasks.tasks.forEach((task) => {
+        queryClient.prefetchQuery({
+          queryKey: ["taskListDetail", task.id],
+          queryFn: () => getTaskDetails(Number(groupId), Number(taskListId), task.id),
+        });
+        queryClient.prefetchQuery({
+          queryKey: ["taskComments", task.id],
+          queryFn: () => getTaskComments(task.id),
+        });
+      });
+    });
+  });
+
   const handleActiveTab = useCallback(
     (index: number, taskList: GroupTaskLists) => {
       setActiveTabIndex(index);
@@ -47,6 +78,16 @@ export default function TaskLists({ taskLists, handleTaskListId, isLoading, isEr
     },
     [teamId]
   );
+
+  const handleTaskClick = useCallback((taskId: number) => {
+    setSelectedTaskId(taskId);
+    setIsSidebarVisible(true);
+  }, []);
+
+  const handleCloseSidebar = useCallback(() => {
+    setIsSidebarVisible(false);
+    setSelectedTaskId(null);
+  }, []);
 
   if (isError) return <div>데이터를 불러오지 못했습니다.</div>;
 
@@ -79,7 +120,9 @@ export default function TaskLists({ taskLists, handleTaskListId, isLoading, isEr
       {!isLoading && (
         <div>
           {taskLists?.tasks && taskLists.tasks.length > 0 ? (
-            taskLists?.tasks.map((task) => <Task key={task.id} task={task} />)
+            taskLists?.tasks.map((task) => (
+              <Task key={task.id} task={task} onClick={() => handleTaskClick(task.id)} />
+            ))
           ) : (
             <div className="mt-191 flex items-center justify-center text-center text-14 font-medium leading-[17px] text-text-default md:mt-345 lg:mt-310">
               아직 할 일이 없습니다.
@@ -87,6 +130,14 @@ export default function TaskLists({ taskLists, handleTaskListId, isLoading, isEr
             </div>
           )}
         </div>
+      )}
+      {isSidebarVisible && selectedTaskId && (
+        <Sidebar
+          groupId={groupId}
+          taskListId={taskListId}
+          taskId={selectedTaskId}
+          onClose={handleCloseSidebar}
+        />
       )}
     </section>
   );

--- a/src/components/task-list-page/TaskList.tsx
+++ b/src/components/task-list-page/TaskList.tsx
@@ -40,6 +40,7 @@ export default function TaskLists({
     queryKey: ["group", teamId],
     queryFn: () => getGroup(Number(teamId)),
     enabled: !!teamId,
+    staleTime: Infinity,
   });
 
   useEffect(() => {
@@ -61,10 +62,12 @@ export default function TaskLists({
         queryClient.prefetchQuery({
           queryKey: ["taskListDetail", task.id],
           queryFn: () => getTaskDetails(Number(groupId), Number(taskListId), task.id),
+          staleTime: Infinity,
         });
         queryClient.prefetchQuery({
           queryKey: ["taskComments", task.id],
           queryFn: () => getTaskComments(task.id),
+          staleTime: Infinity,
         });
       });
     });

--- a/src/pages/teams/[teamId]/task-lists/[taskListsId]/index.tsx
+++ b/src/pages/teams/[teamId]/task-lists/[taskListsId]/index.tsx
@@ -128,6 +128,8 @@ export default function TaskListPage({ dehydratedState }: { dehydratedState: Deh
           isLoading={taskListsLoading}
           isError={taskListsError}
           handleTaskListId={handleTaskListId}
+          groupId={teamId as string}
+          taskListId={taskListId as string}
         />
       </div>
       <Button


### PR DESCRIPTION
## 연관된 지라 이슈

FE-55

## 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- [x] 사이드바 디자인 및 반응형 디자인 구현
- [x] 상세보기 데이터, 댓글 prefetch
- [x] 상세보기 댓글 옵티미스틱 디자인 적용
- [x] 할일 완료하기, 취소하기 버튼 누를시 task 컴포넌트에서도 체크, 체크해제

## 스크린샷
pc
![image](https://github.com/user-attachments/assets/76b37106-9079-44da-8ae2-a3f5fd08a943)

tablet
![image](https://github.com/user-attachments/assets/05c5f532-0897-486c-9fbd-c936134d2778)

mobile
![image](https://github.com/user-attachments/assets/6a9122b5-3e42-44dd-b225-6e9fba3fd881)

## 코멘트 및 논의 사항

타입도수정하고.. task 컴포넌트도 건들였습니다
뭔가 한게 없는거같은데 한게 많네요
코드가 조금 지저분하긴 한데 다 필요한 애들이에요 ㅠㅠ

눌렀을때 스르륵? 그런 애니메이션은 아직 안했고, 상세보기가 켜져있는 상태에서 다른 할일을 누르면 그 상세보기가 켜지지만 다른 할일목록(탭)을 눌렀을땐 꺼지진 않습니다
